### PR TITLE
Fix a few typos to references in the docker-compose repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ or via tctl we have to start the Temporal Server with Elasticsearch enabled:
 ```shell script
 git clone https://github.com/temporalio/docker-compose.git
 cd  docker-compose
-docker-compose -f docker-compose-cas-es.yml up
+docker-compose -f docker-compose-cass-es.yml up
 ```
 
 In case you don't want to run the queries agaist workflow changes, you can start Temporal Server on Docker
@@ -24,7 +24,7 @@ without Elasticsearch enabled:
 ```shell script
 git clone https://github.com/temporalio/docker-compose.git
 cd  docker-compose
-docker-compose -f docker-compose-cas-es.yml up
+docker-compose -f docker-compose-cass.yml up
 ```
 
 #### 2. Run the demo


### PR DESCRIPTION
This PR fixes two typos in README.md that refer to the `docker-compose-cass-es.yml` and `docker-compose-cass-es.yml` files in the temporal docker-compose repo. 